### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-F2   KEYWORD1
-G2   KEYWORD1
-perm   KEYWORD1
-permMod12   KEYWORD1
+F2	KEYWORD1
+G2	KEYWORD1
+perm	KEYWORD1
+permMod12	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init    KEYWORD2
-fastFloor  KEYWORD2
-dot KEYWORD2
-noise KEYWORD2
+init	KEYWORD2
+fastFloor	KEYWORD2
+dot	KEYWORD2
+noise	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords